### PR TITLE
Add custom sample limit.

### DIFF
--- a/examples/infer/main.go
+++ b/examples/infer/main.go
@@ -20,7 +20,7 @@ func main() {
 	}
 	fmt.Println("## Raw Table ##")
 	fmt.Println(tab)
-	sch, err := schema.Infer(tab)
+	sch, err := schema.Infer(tab, schema.SampleLimit(-1))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/infer/main.go
+++ b/examples/infer/main.go
@@ -20,7 +20,7 @@ func main() {
 	}
 	fmt.Println("## Raw Table ##")
 	fmt.Println(tab)
-	sch, err := schema.Infer(tab, schema.SampleLimit(-1))
+	sch, err := schema.Infer(tab, schema.SampleLimit(schema.SampleAllRows))
 	if err != nil {
 		panic(err)
 	}

--- a/schema/infer.go
+++ b/schema/infer.go
@@ -43,8 +43,16 @@ var (
 	noConstraints = Constraints{}
 )
 
-// Default maximum number of rows used to infer schema.
-const defaultMaxNumRowsInfer = 100
+const (
+	// SampleAllRows can be passed to schema.SampleLimit(int) to sample all rows.
+	// schema.SampleLimit(int) is an optional argument to
+	// schema.Infer(table.Table, ...InferOpts)
+	SampleAllRows = -1
+	// Default maximum number of rows used to infer schema.
+	// This can be changed by passing schema.SampleLimit(int) to
+	// schema.Infer(table.Table, ...InferOpts)
+	defaultMaxNumRowsInfer = 100
+)
 
 // Infer infers a schema from a slice of the tabular data. For columns that contain
 // cells that can inferred as different types, the most popular type is set as the field

--- a/schema/infer.go
+++ b/schema/infer.go
@@ -138,8 +138,14 @@ func infer(headers []string, table [][]string) (*Schema, error) {
 // will inferred as being of type "number" ("integer" can be implicitly cast to "number").
 //
 // For medium to big tables, this method is faster than the Infer.
-func InferImplicitCasting(tab table.Table) (*Schema, error) {
-	s, err := sample(tab, &inferConfig{})
+func InferImplicitCasting(tab table.Table, opts ...InferOpts) (*Schema, error) {
+	cfg := &inferConfig{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, err
+		}
+	}
+	s, err := sample(tab, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/schema/infer_test.go
+++ b/schema/infer_test.go
@@ -46,6 +46,56 @@ func ExampleInferImplicitCasting() {
 	// {Name:Height Type:number Format:default}
 }
 
+func TestInferSampleLimit(t *testing.T) {
+	data := []struct {
+		desc        string
+		sampleLimit int
+		headers     []string
+		table       [][]string
+		want        int
+	}{
+		{"SampleZero", 0, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+		{"SampleOne", 1, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 1},
+		{"SampleTwo", 2, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 2},
+		{"SampleThree", 3, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+		{"SampleTen", 10, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+		{"SampleMinusOne", -1, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+		{"SampleMinusTen", -10, []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+		{"SampleEmptyZero", 0, []string{"Age"}, [][]string{}, 0},
+		{"SampleEmptyOne", 1, []string{"Age"}, [][]string{}, 0},
+		{"SampleEmptyMinusTen", -10, []string{"Age"}, [][]string{}, 0},
+	}
+	for _, d := range data {
+		t.Run(d.desc, func(t *testing.T) {
+			is := is.New(t)
+			s, err := sample(table.FromSlices(d.headers, d.table), &inferConfig{sampleLimit: d.sampleLimit})
+			is.NoErr(err)
+
+			is.Equal(len(s), d.want)
+		})
+	}
+	t.Run("LimitNotSpecified", func(t *testing.T) {
+		data := []struct {
+			desc    string
+			headers []string
+			table   [][]string
+			want    int
+		}{
+			{"SampleDefault", []string{"Age"}, [][]string{[]string{"1"}, []string{"2"}, []string{"3"}}, 3},
+			{"SampleDefault", []string{"Age"}, [][]string{}, 0},
+		}
+		for _, d := range data {
+			t.Run(d.desc, func(t *testing.T) {
+				is := is.New(t)
+				s, err := sample(table.FromSlices(d.headers, d.table), &inferConfig{})
+				is.NoErr(err)
+
+				is.Equal(len(s), d.want)
+			})
+		}
+	})
+}
+
 func TestInfer(t *testing.T) {
 	data := []struct {
 		desc    string


### PR DESCRIPTION
This enables specifying the infer sample limit to be a value other than the default 100.

I need this feature now, so have gone ahead and implemented it, but am happy to change it as required.

One reason I needed it was to help debug https://github.com/frictionlessdata/tableschema-go/issues/71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frictionlessdata/tableschema-go/72)
<!-- Reviewable:end -->
