### PR TITLE
Infer with precedence

### DIFF
--- a/schema/infer.go
+++ b/schema/infer.go
@@ -162,10 +162,10 @@ func inferWithPrecedence(headers []string, table [][]string) (*Schema, error) {
 		StringPrecedence
 		GeoPointPrecedence
 		BooleanPrecedence
-		IntegerPrecedence
-		NumberPrecedence
 		YearPrecedence
 		YearMonthPrecedence
+		IntegerPrecedence
+		NumberPrecedence
 		TimePrecedence
 		DatePrecedence
 		DateTimePrecedence

--- a/schema/infer.go
+++ b/schema/infer.go
@@ -69,23 +69,10 @@ func Infer(tab table.Table, opts ...InferOpts) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cfg.inferWithPrecedence {
+		return inferWithPrecedence(tab.Headers(), s)
+	}
 	return infer(tab.Headers(), s)
-}
-
-// InferWithPrecedence infers a schema using a type precedence list to
-// prioritize a type when there is ambiguity eg 1 as int before bool.
-func InferWithPrecedence(tab table.Table, opts ...InferOpts) (*Schema, error) {
-	cfg := &inferConfig{}
-	for _, opt := range opts {
-		if err := opt(cfg); err != nil {
-			return nil, err
-		}
-	}
-	s, err := sample(tab, cfg)
-	if err != nil {
-		return nil, err
-	}
-	return inferWithPrecedence(tab.Headers(), s)
 }
 
 func sample(tab table.Table, cfg *inferConfig) ([][]string, error) {
@@ -337,13 +324,23 @@ func findType(value string, checkOrder []string) string {
 type InferOpts func(c *inferConfig) error
 
 type inferConfig struct {
-	sampleLimit int
+	sampleLimit         int
+	inferWithPrecedence bool
 }
 
 // SampleLimit specifies the maximum number of rows to sample for inference.
 func SampleLimit(limit int) InferOpts {
 	return func(c *inferConfig) error {
 		c.sampleLimit = limit
+		return nil
+	}
+}
+
+// InferWithPrecedence infers a schema using a type precedence list to
+// prioritize a type when there is ambiguity eg 1 as int before bool.
+func InferWithPrecedence(b bool) InferOpts {
+	return func(c *inferConfig) error {
+		c.inferWithPrecedence = b
 		return nil
 	}
 }

--- a/schema/infer.go
+++ b/schema/infer.go
@@ -156,8 +156,10 @@ func inferWithPrecedence(headers []string, table [][]string) (*Schema, error) {
 	// These consts specify the type order of precedence when inferring.
 	// The types are weighted from least specific to most specific.
 	const (
-		ObjectPrecedence TypePrecedence = iota
+		AnyPrecedence TypePrecedence = iota
+		ObjectPrecedence
 		ArrayPrecedence
+		StringPrecedence
 		GeoPointPrecedence
 		BooleanPrecedence
 		IntegerPrecedence
@@ -172,8 +174,10 @@ func inferWithPrecedence(headers []string, table [][]string) (*Schema, error) {
 
 	// A lookup table to get precedence weight from type name.
 	typePrecedenceMap := map[string]TypePrecedence{
+		AnyType:       AnyPrecedence,
 		ObjectType:    ObjectPrecedence,
 		ArrayType:     ArrayPrecedence,
+		StringType:    StringPrecedence,
 		GeoPointType:  GeoPointPrecedence,
 		BooleanType:   BooleanPrecedence,
 		IntegerType:   IntegerPrecedence,

--- a/schema/infer_test.go
+++ b/schema/infer_test.go
@@ -12,7 +12,9 @@ import (
 
 // Demonstrations.
 
-// Demonstrations of incorrect inference.
+/* Demonstrations of incorrect inference.
+	NOTE 	These are here only for review experimentation -
+			they fail and won't pass CI tests.
 
 // ExampleInferBoolWrongly should infer Value to be number, but infers bool.
 func ExampleInferBoolWrongly() {
@@ -59,6 +61,7 @@ func ExampleInferStringWrongly() {
 	// {Name:Item Type:string Format:default}
 	// {Name:Value Type:number Format:default}
 }
+*/
 
 // Demostration of precedence inference.
 
@@ -73,7 +76,7 @@ func ExampleInferPrecedenceNumberNotBool() {
 			[]string{"D", "0"},
 			[]string{"E", "5.2"},
 		})
-	s, _ := InferWithPrecedence(tab)
+	s, _ := Infer(tab, InferWithPrecedence(true))
 	fmt.Println("Fields:")
 	for _, f := range s.Fields {
 		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)
@@ -98,7 +101,7 @@ func ExampleInferPrecedenceNumberNotString() {
 			[]string{"H", "0"},
 			[]string{"I", "5.2"},
 		})
-	s, _ := InferWithPrecedence(tab)
+	s, _ := Infer(tab, InferWithPrecedence(true))
 	fmt.Println("Fields:")
 	for _, f := range s.Fields {
 		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)

--- a/schema/infer_test.go
+++ b/schema/infer_test.go
@@ -10,6 +10,106 @@ import (
 	"github.com/frictionlessdata/tableschema-go/table"
 )
 
+// Demonstrations.
+
+// Demonstrations of incorrect inference.
+
+// ExampleInferBoolWrongly should infer Value to be number, but infers bool.
+func ExampleInferBoolWrongly() {
+	tab := table.FromSlices(
+		[]string{"Item", "Value"},
+		[][]string{
+			[]string{"A", "1.2"},
+			[]string{"B", "0"},
+			[]string{"C", "0"},
+			[]string{"D", "0"},
+			[]string{"E", "5.2"},
+		})
+	s, _ := Infer(tab)
+	fmt.Println("Fields:")
+	for _, f := range s.Fields {
+		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)
+	}
+	// Output: Fields:
+	// {Name:Item Type:string Format:default}
+	// {Name:Value Type:number Format:default}
+}
+
+// ExampleInferStringWrongly should infer Value to be number, but infers string.
+func ExampleInferStringWrongly() {
+	tab := table.FromSlices(
+		[]string{"Item", "Value"},
+		[][]string{
+			[]string{"A", "1.2"},
+			[]string{"B", "0"},
+			[]string{"C", ""},
+			[]string{"D", ""},
+			[]string{"E", ""},
+			[]string{"F", ""},
+			[]string{"G", ""},
+			[]string{"H", "0"},
+			[]string{"I", "5.2"},
+		})
+	s, _ := Infer(tab)
+	fmt.Println("Fields:")
+	for _, f := range s.Fields {
+		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)
+	}
+	// Output: Fields:
+	// {Name:Item Type:string Format:default}
+	// {Name:Value Type:number Format:default}
+}
+
+// Demostration of precedence inference.
+
+// ExampleInferPrecedenceNumberNotBool correctly infers as number.
+func ExampleInferPrecedenceNumberNotBool() {
+	tab := table.FromSlices(
+		[]string{"Item", "Value"},
+		[][]string{
+			[]string{"A", "1.2"},
+			[]string{"B", "0"},
+			[]string{"C", "0"},
+			[]string{"D", "0"},
+			[]string{"E", "5.2"},
+		})
+	s, _ := InferWithPrecedence(tab)
+	fmt.Println("Fields:")
+	for _, f := range s.Fields {
+		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)
+	}
+	// Output: Fields:
+	// {Name:Item Type:string Format:default}
+	// {Name:Value Type:number Format:default}
+}
+
+// ExampleInferPrecedenceNumberNotString correctly infers as number.
+func ExampleInferPrecedenceNumberNotString() {
+	tab := table.FromSlices(
+		[]string{"Item", "Value"},
+		[][]string{
+			[]string{"A", "1.2"},
+			[]string{"B", "0"},
+			[]string{"C", ""},
+			[]string{"D", ""},
+			[]string{"E", ""},
+			[]string{"F", ""},
+			[]string{"G", ""},
+			[]string{"H", "0"},
+			[]string{"I", "5.2"},
+		})
+	s, _ := InferWithPrecedence(tab)
+	fmt.Println("Fields:")
+	for _, f := range s.Fields {
+		fmt.Printf("{Name:%s Type:%s Format:%s}\n", f.Name, f.Type, f.Format)
+	}
+	// Output: Fields:
+	// {Name:Item Type:string Format:default}
+	// {Name:Value Type:number Format:default}
+}
+
+// End of Demonstrations
+
 func Exampleinfer() {
 	tab := table.FromSlices(
 		[]string{"Person", "Height"},


### PR DESCRIPTION
As you pointed out, this PR removes the public InferWithPrecedence function, replacing it with an InferOpts option to be passed to the Infer function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frictionlessdata/tableschema-go/74)
<!-- Reviewable:end -->
