### PR TITLE
CastTable reports all errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/frictionlessdata/tableschema-go
 
+go 1.14
+
 require (
 	github.com/matryer/is v0.0.0-20170112134659-c0323ceb4e99
 	github.com/satori/go.uuid v1.1.0


### PR DESCRIPTION
# Overview

`CastTable` reports all errors instead of only the first one.

---

Please preserve this line to notify @danielfireman (lead of this repository)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frictionlessdata/tableschema-go/89)
<!-- Reviewable:end -->
